### PR TITLE
Simplify the JSON response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.swp
 .coverage
 .vagrant
+
+# added by GitSavvy
+/application.log

--- a/explainshell/web/views.py
+++ b/explainshell/web/views.py
@@ -1,7 +1,7 @@
 import logging, itertools, urllib
 import markupsafe
 
-from flask import render_template, request, redirect
+from flask import render_template, request, redirect, jsonify
 
 import bashlex.errors
 
@@ -18,40 +18,61 @@ def index():
 def about():
     return render_template('about.html')
 
-@app.route('/explain')
-def explain():
+STATUS_TYPE_TEMPLATES = {
+    'success': 'explain.html',
+    'error': 'errors/error.html',
+    'missingmanpage': 'errors/missingmanpage.html',
+    'parsingerror': 'errors/parsingerror.html',
+}
+
+def formatted_response(fmt, status, **kwargs):
+    if fmt == 'html':
+        return render_template(STATUS_TYPE_TEMPLATES[status], **kwargs)
+    else:
+        return jsonify(status=status, **kwargs)
+
+def generic_explain(fmt):
     if 'cmd' not in request.args or not request.args['cmd'].strip():
         return redirect('/')
     command = request.args['cmd'].strip()
     command = command[:1000] # trim commands longer than 1000 characters
     if '\n' in command:
-        return render_template('errors/error.html', title='parsing error!',
-                               message='no newlines please')
+        return formatted_response(fmt, 'error', title='parsing error!',
+                                  message='no newlines please')
 
     s = store.store('explainshell', config.MONGO_URI)
     try:
         matches, helptext = explaincommand(command, s)
-        return render_template('explain.html',
-                               matches=matches,
-                               helptext=helptext,
-                               getargs=command)
+        return formatted_response(fmt, 'success',
+                                  matches=matches,
+                                  helptext=helptext,
+                                  getargs=command)
 
     except errors.ProgramDoesNotExist, e:
-        return render_template('errors/missingmanpage.html', title='missing man page', e=e)
+        return formatted_response('missingmanpage', title='missing man page', e=e)
     except bashlex.errors.ParsingError, e:
         logger.warn('%r parsing error: %s', command, e.message)
-        return render_template('errors/parsingerror.html', title='parsing error!', e=e)
+        return formatted_response('parsingerror', title='parsing error!', e=e)
     except NotImplementedError, e:
         logger.warn('not implemented error trying to explain %r', command)
         msg = ("the parser doesn't support %r constructs in the command you tried. you may "
                "<a href='https://github.com/idank/explainshell/issues'>report a "
                "bug</a> to have this added, if one doesn't already exist.") % e.args[0]
 
-        return render_template('errors/error.html', title='error!', message=msg)
+        return formatted_response('error', title='error!', message=msg)
     except:
         logger.error('uncaught exception trying to explain %r', command, exc_info=True)
         msg = 'something went wrong... this was logged and will be checked'
-        return render_template('errors/error.html', title='error!', message=msg)
+        return formatted_response('error', title='error!', message=msg)
+
+
+@app.route('/api/explain')
+def explain_api():
+    return generic_explain('json')
+
+@app.route('/explain')
+def explain():
+    return generic_explain('html')
 
 @app.route('/explain/<program>', defaults={'section' : None})
 @app.route('/explain/<section>/<program>')

--- a/explainshell/web/views.py
+++ b/explainshell/web/views.py
@@ -29,6 +29,8 @@ def formatted_response(fmt, status, **kwargs):
     if fmt == 'html':
         return render_template(STATUS_TYPE_TEMPLATES[status], **kwargs)
     else:
+        if 'e' in kwargs:
+            kwargs['e'] = repr(kwargs['e'])
         return jsonify(status=status, **kwargs)
 
 def generic_explain(fmt):
@@ -49,21 +51,21 @@ def generic_explain(fmt):
                                   getargs=command)
 
     except errors.ProgramDoesNotExist, e:
-        return formatted_response('missingmanpage', title='missing man page', e=e)
+        return formatted_response(fmt, 'missingmanpage', title='missing man page', e=e)
     except bashlex.errors.ParsingError, e:
         logger.warn('%r parsing error: %s', command, e.message)
-        return formatted_response('parsingerror', title='parsing error!', e=e)
+        return formatted_response(fmt, 'parsingerror', title='parsing error!', e=e)
     except NotImplementedError, e:
         logger.warn('not implemented error trying to explain %r', command)
         msg = ("the parser doesn't support %r constructs in the command you tried. you may "
                "<a href='https://github.com/idank/explainshell/issues'>report a "
                "bug</a> to have this added, if one doesn't already exist.") % e.args[0]
 
-        return formatted_response('error', title='error!', message=msg)
+        return formatted_response(fmt, 'error', title='error!', message=msg)
     except:
         logger.error('uncaught exception trying to explain %r', command, exc_info=True)
         msg = 'something went wrong... this was logged and will be checked'
-        return formatted_response('error', title='error!', message=msg)
+        return formatted_response(fmt, 'error', title='error!', message=msg)
 
 
 @app.route('/api/explain')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-markupsafe
-Flask
-nltk
-nose
-pymongo
-bashlex
+bashlex==0.6
+Flask==0.10.1
+MarkupSafe==0.23
+mock==1.0.1
+nltk==3.0.2
+nose==1.3.7
+pymongo==2.7

--- a/tests/test-views.py
+++ b/tests/test-views.py
@@ -48,33 +48,32 @@ class FlaskrTestCase(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data)
         self.assertEqual(data, {
-            'getargs': 'bar -a --a -?',
-            'helptext': [['bar synopsis', 'help-0'],
-                         ['-a desc', 'help-1'],
-                         ['-? help text', 'help-2']],
-            'matches': [{'commandclass': 'command0 simplecommandstart',
-                         'end': 3,
-                         'helpclass': 'help-0',
-                         'match': 'bar(1)',
-                         'name': 'bar',
-                         'section': '1',
-                         'source': 'bar',
-                         'spaces': ' ',
-                         'start': 0,
-                         'suggestions': []},
-                        {'commandclass': 'command0',
-                         'end': 10,
-                         'helpclass': 'help-1',
-                         'match': '-a --a',
-                         'spaces': ' ',
-                         'start': 4},
-                        {'commandclass': 'command0',
-                         'end': 13,
-                         'helpclass': 'help-2',
-                         'match': '-?',
-                         'spaces': '',
-                         'start': 11}],
-            'status': 'success'})
+            'matches': [{
+                'end': 3,
+                'name': 'bar',
+                'source': 'bar',
+                'section': '1',
+                'suggestions': [],
+                'commandclass': 'command0 simplecommandstart',
+                'start': 0,
+                'helpHTML': 'bar synopsis',
+                'spaces': ' ',
+                'match': 'bar(1)'
+            }, {
+                'end': 10,
+                'commandclass': 'command0',
+                'start': 4,
+                'helpHTML': '-a desc',
+                'spaces': ' ',
+                'match': '-a --a'
+            }, {
+                'end': 13,
+                'commandclass': 'command0',
+                'start': 11,
+                'helpHTML': '-? help text',
+                'spaces': '',
+                'match': '-?'
+            }]})
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test-views.py
+++ b/tests/test-views.py
@@ -19,10 +19,24 @@ class FlaskrTestCase(unittest.TestCase):
         self.addCleanup(store_patcher.stop)
         self.app = app.test_client()
 
-    def test_explain_view_missing_cmd(self):
+    def test_explain_view_missing_query_params(self):
         rv = self.app.get('/explain')
         self.assertEqual(rv.status_code, 302)
         self.assertIn('You should be redirected automatically', rv.data)
+
+    def test_missing_error(self):
+        rv = self.app.get('/explain?cmd=zoomba -l')
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn('No man page found for ', rv.data)
+
+    def test_missing_error_json(self):
+        rv = self.app.get('/api/explain?cmd=zoomba -l')
+        self.assertEqual(rv.status_code, 200)
+        data = json.loads(rv.data)
+        self.assertEqual(data, {
+            'e': "ProgramDoesNotExist(u'zoomba',)",
+            'status': 'missingmanpage',
+            'title': 'missing man page'})
 
     def test_explain_view_ok(self):
         rv = self.app.get('/explain?cmd=%s' % self.cmd)
@@ -33,8 +47,6 @@ class FlaskrTestCase(unittest.TestCase):
         rv = self.app.get('/api/explain?cmd=%s' % self.cmd)
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data)
-        from pprint import pprint
-        pprint(data)
         self.assertEqual(data, {
             'getargs': 'bar -a --a -?',
             'helptext': [['bar synopsis', 'help-0'],

--- a/tests/test-views.py
+++ b/tests/test-views.py
@@ -1,0 +1,68 @@
+import json
+import mock
+import unittest
+
+from explainshell.web import app
+from tests import helpers
+
+s = helpers.mockstore()
+
+
+class FlaskrTestCase(unittest.TestCase):
+    cmd = 'bar -a --a -?'
+
+    def setUp(self):
+        app.config['TESTING'] = True
+        # mock store
+        store_patcher = mock.patch('explainshell.store.store', return_value=s)
+        store_patcher.start()
+        self.addCleanup(store_patcher.stop)
+        self.app = app.test_client()
+
+    def test_explain_view_missing_cmd(self):
+        rv = self.app.get('/explain')
+        self.assertEqual(rv.status_code, 302)
+        self.assertIn('You should be redirected automatically', rv.data)
+
+    def test_explain_view_ok(self):
+        rv = self.app.get('/explain?cmd=%s' % self.cmd)
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn('<a href="/explain/1/bar">bar(1)</a></span>', rv.data)
+
+    def test_explain_view_json_ok(self):
+        rv = self.app.get('/api/explain?cmd=%s' % self.cmd)
+        self.assertEqual(rv.status_code, 200)
+        data = json.loads(rv.data)
+        from pprint import pprint
+        pprint(data)
+        self.assertEqual(data, {
+            'getargs': 'bar -a --a -?',
+            'helptext': [['bar synopsis', 'help-0'],
+                         ['-a desc', 'help-1'],
+                         ['-? help text', 'help-2']],
+            'matches': [{'commandclass': 'command0 simplecommandstart',
+                         'end': 3,
+                         'helpclass': 'help-0',
+                         'match': 'bar(1)',
+                         'name': 'bar',
+                         'section': '1',
+                         'source': 'bar',
+                         'spaces': ' ',
+                         'start': 0,
+                         'suggestions': []},
+                        {'commandclass': 'command0',
+                         'end': 10,
+                         'helpclass': 'help-1',
+                         'match': '-a --a',
+                         'spaces': ' ',
+                         'start': 4},
+                        {'commandclass': 'command0',
+                         'end': 13,
+                         'helpclass': 'help-2',
+                         'match': '-?',
+                         'spaces': '',
+                         'start': 11}],
+            'status': 'success'})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This simplifies the JSON response so it's no longer tied to the structure that the HTML templates expect.

@asfaltboy @idank Once this is merged in (to `asfaltboy/explainshell`), https://github.com/idank/explainshell/pull/125 should automatically update and be ready to merge 👌 